### PR TITLE
Fix production - app not binding to correct port

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,3 @@
-#\ -p 4567
 require './app/app.rb'
 
 run Honker


### PR DESCRIPTION

Error message (found in logs) - "Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch"

Explanation - Rackup is not receiving the correct port generated by Heroku, as the port is currently being overwritten.